### PR TITLE
Fix --restore/--store with --watch combination

### DIFF
--- a/claude-profiles.mjs
+++ b/claude-profiles.mjs
@@ -2542,16 +2542,22 @@ async function getDetailedAuthStatus() {
       await listProfiles();
     } else if (argv.store && argv.watch) {
       // Store first, then watch
-      await saveProfile(argv.store, options);
+      // Handle case where --store is boolean (true) when no value provided
+      const storeProfileName = typeof argv.store === 'boolean' ? argv.watch : argv.store;
+      const watchProfileName = argv.watch;
+      await saveProfile(storeProfileName, options);
       log('INFO', '');
       log('INFO', '🔄 Now starting watch mode...');
-      await watchProfile(argv.watch, options);
+      await watchProfile(watchProfileName, options);
     } else if (argv.restore && argv.watch) {
       // Restore first, then watch
-      await restoreProfile(argv.restore);
+      // Handle case where --restore is boolean (true) when no value provided
+      const restoreProfileName = typeof argv.restore === 'boolean' ? argv.watch : argv.restore;
+      const watchProfileName = argv.watch;
+      await restoreProfile(restoreProfileName);
       log('INFO', '');
       log('INFO', '🔄 Now starting watch mode...');
-      await watchProfile(argv.watch, options);
+      await watchProfile(watchProfileName, options);
     } else if (argv.store) {
       await saveProfile(argv.store, options);
     } else if (argv.restore) {


### PR DESCRIPTION
## Summary
- Fixed issue where `--restore --watch profilename` and `--store --watch profilename` commands were not working correctly
- The problem was that yargs parsed `--restore` and `--store` as boolean flags when no value immediately followed them
- Added logic to detect when these options are boolean and use the `--watch` value as the profile name for both operations

## Problem
When users ran commands like:
- `claude-profiles --restore --watch gitpod`
- `claude-profiles --store --watch myprofile`

The CLI would fail because yargs interpreted `--restore`/`--store` as boolean `true` rather than expecting a profile name value.

## Solution
Added type checking in the execution logic to handle this case:
- When `--restore` or `--store` is a boolean (true), use the `--watch` value as the profile name
- This allows both shortened syntax (`--restore --watch profile`) and explicit syntax (`--restore profile --watch profile`)

## Test Plan
- [x] Test `--restore --watch profilename` - should restore and then watch the same profile
- [x] Test `--store --watch profilename` - should store and then watch the same profile  
- [x] Test explicit values `--restore profile1 --watch profile2` - should still work with different profiles
- [x] Verify existing functionality still works

Fixes #24

🤖 Generated with [Claude Code](https://claude.ai/code)