### PR TITLE
Fix: Restore and watch combination now works correctly

### DIFF
--- a/claude-profiles.mjs
+++ b/claude-profiles.mjs
@@ -2364,6 +2364,31 @@ const argv = yargs(hideBin(process.argv))
       throw new Error('Please specify one of: --list, --store, --restore, --delete, --verify, --watch, or combine --restore/--store with --watch');
     }
     
+    // Check if restore or store were provided without values (parsed as boolean true or empty string)
+    if (argv.restore === true || argv.restore === '') {
+      throw new Error('--restore requires a profile name. Usage: --restore <profile_name>');
+    }
+    if (argv.store === true || argv.store === '') {
+      throw new Error('--store requires a profile name. Usage: --store <profile_name>');
+    }
+    if (argv.watch === true || argv.watch === '') {
+      throw new Error('--watch requires a profile name. Usage: --watch <profile_name>');
+    }
+    if (argv.delete === true || argv.delete === '') {
+      throw new Error('--delete requires a profile name. Usage: --delete <profile_name>');
+    }
+    if (argv.verify === true || argv.verify === '') {
+      throw new Error('--verify requires a profile name. Usage: --verify <profile_name>');
+    }
+    
+    // Check for invalid values that look like other flags
+    if (typeof argv.restore === 'string' && argv.restore.startsWith('--')) {
+      throw new Error(`--restore requires a profile name, but got another flag: ${argv.restore}. Usage: --restore <profile_name> --watch <profile_name>`);
+    }
+    if (typeof argv.store === 'string' && argv.store.startsWith('--')) {
+      throw new Error(`--store requires a profile name, but got another flag: ${argv.store}. Usage: --store <profile_name> --watch <profile_name>`);
+    }
+    
     // Allow combining --restore or --store with --watch, but not other combinations
     if (mainOptions.length > 1) {
       const hasWatch = !!argv.watch;


### PR DESCRIPTION
## Summary
- Fixed issue where `--restore --watch gitpod` would skip the restore step and go directly to watch mode
- Improved argument validation to catch incorrectly formatted commands
- Added helpful error messages to guide users to the correct syntax

## Problem
When users tried to use `--restore` and `--watch` together with syntax like `--restore --watch gitpod`, the tool would:
1. Parse `--restore` as an empty string value
2. Skip the restore operation entirely
3. Go directly to watch mode with missing files

## Solution
Added comprehensive argument validation that:
- Detects when options like `--restore`, `--store`, `--watch` receive empty string or boolean values
- Catches when option values are other flags (e.g., `--restore` getting `--watch` as its value)
- Provides clear error messages showing the correct syntax

## Test Results
✅ `--restore gitpod --watch gitpod` - Works correctly (restore then watch)
✅ `--store test --watch test` - Works correctly (store then watch)  
✅ `--restore --watch gitpod` - Now shows error: "--restore requires a profile name. Usage: --restore <profile_name>"
✅ `--store --watch test` - Now shows error: "--store requires a profile name. Usage: --store <profile_name>"

## Examples
Correct usage:
```bash
# Restore a profile and then watch for changes
claude-profiles --restore work --watch work

# Store current state and then watch for changes
claude-profiles --store work --watch work
```

Fixes #24

🤖 Generated with [Claude Code](https://claude.ai/code)