### PR TITLE
Fix --restore option with --watch did not work

### DIFF
--- a/examples/test-restore-watch.sh
+++ b/examples/test-restore-watch.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+# Test script for --restore with --watch combination
+
+echo "Testing --restore with --watch combination"
+echo "==========================================="
+echo ""
+
+# Test 1: Basic restore with watch
+echo "Test 1: Basic --restore with --watch"
+echo "Command: ./claude-profiles.mjs --restore test-profile --watch test-profile --verbose"
+timeout 5s ./claude-profiles.mjs --restore test-profile --watch test-profile --verbose 2>&1 | head -30
+echo ""
+
+# Test 2: Restore with watch and skip-projects
+echo "Test 2: --restore with --watch and --skip-projects"
+echo "Command: ./claude-profiles.mjs --restore test-profile --watch test-profile --skip-projects --verbose"
+timeout 5s ./claude-profiles.mjs --restore test-profile --watch test-profile --skip-projects --verbose 2>&1 | head -30
+echo ""
+
+# Test 3: Just restore with skip-projects (no watch)
+echo "Test 3: Just --restore with --skip-projects (no watch)"
+echo "Command: ./claude-profiles.mjs --restore test-profile --skip-projects --verbose"
+./claude-profiles.mjs --restore test-profile --skip-projects --verbose 2>&1 | head -30
+echo ""
+
+echo "Test completed!"


### PR DESCRIPTION
## Summary
- Fixed the `--restore` option to properly accept and use options like `--skip-projects` when combined with `--watch`
- The issue was that `restoreProfile` function wasn't accepting options parameter, causing it to ignore flags like `--skip-projects`

## What Changed
- Updated `restoreProfile()` function signature to accept `options` parameter  
- Modified restore logic to use `getBackupPaths(options)` instead of hardcoded `BACKUP_PATHS`
- Added proper handling of `skipProjects` flag during restore using rsync to exclude projects folder
- Updated all calls to `restoreProfile()` to pass the options object

## Test Plan
- [x] Modified `restoreProfile` function to accept options
- [x] Updated function calls to pass options
- [x] Added test script `examples/test-restore-watch.sh` for verification
- [x] Syntax validation passes

## How to Test
```bash
# Test restore with watch and skip-projects
./claude-profiles.mjs --restore <profile> --watch <profile> --skip-projects --verbose

# The restore operation should now properly exclude the projects folder
```

Fixes #29

🤖 Generated with [Claude Code](https://claude.ai/code)