### PR TITLE
Fix yargs import compatibility for Bun environment

### DIFF
--- a/claude-profiles.mjs
+++ b/claude-profiles.mjs
@@ -28,12 +28,15 @@ const { use } = eval(
 );
 
 // Load required packages dynamically with specific versions
-const [{ $ }, yargs, yargsHelpers, archiver] = await Promise.all([
+const [{ $ }, yargsModule, yargsHelpers, archiver] = await Promise.all([
   use('command-stream@0.7.0'),
   use('yargs@17.7.2'),
   use('yargs@17.7.2/helpers'),
   use('archiver@7.0.1')
 ]);
+
+// Handle both CommonJS and ES module exports for yargs in different environments
+const yargs = typeof yargsModule === 'function' ? yargsModule : yargsModule.default || yargsModule;
 
 const { hideBin } = yargsHelpers;
 

--- a/examples/test-yargs-import.mjs
+++ b/examples/test-yargs-import.mjs
@@ -1,0 +1,42 @@
+#!/usr/bin/env node
+
+/**
+ * Test script to verify yargs import works in different environments
+ * This simulates how the main script loads yargs
+ */
+
+console.log('Testing yargs import compatibility...');
+
+// Simulate use-m loading
+const { use } = eval(
+  await fetch('https://unpkg.com/use-m/use.js').then(r => r.text())
+);
+
+// Load yargs the same way as main script
+const yargsModule = await use('yargs@17.7.2');
+const yargsHelpers = await use('yargs@17.7.2/helpers');
+
+// Apply the same compatibility fix
+const yargs = typeof yargsModule === 'function' ? yargsModule : yargsModule.default || yargsModule;
+const { hideBin } = yargsHelpers;
+
+console.log('yargs type:', typeof yargs);
+console.log('yargs is function:', typeof yargs === 'function');
+console.log('hideBin type:', typeof hideBin);
+
+// Test actual usage
+try {
+  const argv = yargs(hideBin(['node', 'test', '--help']))
+    .option('test', {
+      type: 'boolean',
+      description: 'Test option'
+    })
+    .help()
+    .argv;
+  
+  console.log('✅ yargs import and usage test passed!');
+  console.log('Arguments parsed:', argv);
+} catch (error) {
+  console.error('❌ yargs test failed:', error.message);
+  process.exit(1);
+}


### PR DESCRIPTION
## 🐛 Bug Fix

Fixes #31 - claude-profiles does not work in bun-only environment

### 🔍 Problem

The issue was that in Bun environments, dynamically loaded CommonJS modules like `yargs` may be imported as module objects rather than directly as functions. This caused the error:

```
TypeError: yargs is not a function. (In 'yargs(hideBin(process.argv))', 'yargs' is an instance of Module)
```

### ✅ Solution

Added a compatibility layer that handles both cases:
- When `yargs` is imported as a function (typical Node.js behavior)
- When `yargs` is imported as a module object (Bun behavior)

**Changes made:**
1. Renamed the imported module to `yargsModule` to clearly indicate it's the raw module
2. Added compatibility logic: `const yargs = typeof yargsModule === 'function' ? yargsModule : yargsModule.default || yargsModule;`
3. Added a test script to verify the fix works correctly

### 🧪 Testing

- ✅ Created test script that verifies yargs import and usage
- ✅ Confirmed main script works with `--help` option
- ✅ No breaking changes for existing Node.js environments

### 📁 Files Changed

- `claude-profiles.mjs`: Added yargs compatibility layer
- `examples/test-yargs-import.mjs`: Added test script for verification

This fix maintains backward compatibility while ensuring the tool works correctly in Bun environments.

---
🤖 Generated with [Claude Code](https://claude.ai/code)