### PR TITLE
fix: resolve use-m ESM/CJS interop for yargs on Node.js v23+

### DIFF
--- a/.changeset/fix-use-m-esm-cjs-interop.md
+++ b/.changeset/fix-use-m-esm-cjs-interop.md
@@ -1,0 +1,15 @@
+---
+"@link-assistant/claude-profiles": patch
+---
+
+Fix TypeError when running on Node.js v24+ due to use-m ESM/CJS interop
+
+`use-m` wraps CJS modules (like `yargs`) under a `.default` property when
+loading them into an ESM context. On Node.js v24, this causes `yargs` to
+not be callable and `hideBin` to be `undefined`, resulting in:
+
+  TypeError: hideBin is not a function
+  TypeError: yargs is not a function
+
+The fix defensively unwraps `.default` when the loaded value is not already
+a function, and provides a fallback for `hideBin` (which is just `argv.slice(2)`).

--- a/claude-profiles.mjs
+++ b/claude-profiles.mjs
@@ -28,16 +28,19 @@ const { use } = eval(
 );
 
 // Load required packages dynamically with specific versions
-const [{ $ }, _yargs, yargsHelpers, archiver] = await Promise.all([
+const [_commandStream, _yargs, _yargsHelpers, _archiver] = await Promise.all([
   use('command-stream@0.7.0'),
   use('yargs@17.7.2'),
   use('yargs@17.7.2/helpers'),
   use('archiver@7.0.1')
 ]);
 
-// use-m wraps CJS modules under .default in ESM context; unwrap defensively
+// use-m wraps CJS modules under .default in ESM context on Node.js v23+; unwrap defensively
+// command-stream exports $ as a named export at the top level (not under .default)
+const { $ } = _commandStream;
 const yargs = (typeof _yargs === 'function') ? _yargs : (_yargs?.default ?? _yargs);
-const hideBin = yargsHelpers?.hideBin ?? yargsHelpers?.default?.hideBin ?? ((argv) => argv.slice(2));
+const hideBin = _yargsHelpers?.hideBin ?? _yargsHelpers?.default?.hideBin ?? ((argv) => argv.slice(2));
+const archiverFn = (typeof _archiver === 'function') ? _archiver : (_archiver?.default ?? _archiver);
 
 const PROFILE_NAME_REGEX = /^[a-z0-9-]+$/;
 
@@ -1295,7 +1298,7 @@ async function saveProfileSilent(profileName, options = {}) {
   
   try {
     const output = createWriteStream(zipPath);
-    const archive = archiver('zip', { zlib: { level: 9 } });
+    const archive = archiverFn('zip', { zlib: { level: 9 } });
     
     const archivePromise = new Promise((resolve, reject) => {
       output.on('close', () => resolve());
@@ -1567,7 +1570,7 @@ async function saveProfile(profileName, options = {}) {
     
     // Create zip archive
     const output = createWriteStream(zipPath);
-    const archive = archiver('zip', { zlib: { level: 9 } });
+    const archive = archiverFn('zip', { zlib: { level: 9 } });
     
     // Create a promise to track when archiving is complete
     const archivePromise = new Promise((resolve, reject) => {

--- a/claude-profiles.mjs
+++ b/claude-profiles.mjs
@@ -28,14 +28,16 @@ const { use } = eval(
 );
 
 // Load required packages dynamically with specific versions
-const [{ $ }, yargs, yargsHelpers, archiver] = await Promise.all([
+const [{ $ }, _yargs, yargsHelpers, archiver] = await Promise.all([
   use('command-stream@0.7.0'),
   use('yargs@17.7.2'),
   use('yargs@17.7.2/helpers'),
   use('archiver@7.0.1')
 ]);
 
-const { hideBin } = yargsHelpers;
+// use-m wraps CJS modules under .default in ESM context; unwrap defensively
+const yargs = (typeof _yargs === 'function') ? _yargs : (_yargs?.default ?? _yargs);
+const hideBin = yargsHelpers?.hideBin ?? yargsHelpers?.default?.hideBin ?? ((argv) => argv.slice(2));
 
 const PROFILE_NAME_REGEX = /^[a-z0-9-]+$/;
 


### PR DESCRIPTION
## Problem

Closes #55

`claude-profiles` fails on Node.js v23+ (and v24) with errors like:

\`\`\`
TypeError: hideBin is not a function
TypeError: yargs is not a function
TypeError: archiver is not a function
\`\`\`

## Root Cause

`use-m` dynamically loads CJS packages into an ESM context. On newer Node.js versions, it wraps default exports under a `.default` property instead of returning them directly. This affects callable default exports (`yargs`, `archiver`) and named exports accessed via helpers (`yargs/helpers`).

## Fix

Apply defensive `.default` unwrapping to all four `use-m` loaded packages:

\`\`\`diff
-const [{ $ }, _yargs, yargsHelpers, archiver] = await Promise.all([
+const [_commandStream, _yargs, _yargsHelpers, _archiver] = await Promise.all([
   use('command-stream@0.7.0'),
   use('yargs@17.7.2'),
   use('yargs@17.7.2/helpers'),
   use('archiver@7.0.1')
 ]);

-// use-m wraps CJS modules under .default in ESM context; unwrap defensively
+// use-m wraps CJS modules under .default in ESM context on Node.js v23+; unwrap defensively
+// command-stream exports $ as a named export at the top level (not under .default)
+const { $ } = _commandStream;
 const yargs = (typeof _yargs === 'function') ? _yargs : (_yargs?.default ?? _yargs);
-const hideBin = yargsHelpers?.hideBin ?? yargsHelpers?.default?.hideBin ?? ((argv) => argv.slice(2));
+const hideBin = _yargsHelpers?.hideBin ?? _yargsHelpers?.default?.hideBin ?? ((argv) => argv.slice(2));
+const archiverFn = (typeof _archiver === 'function') ? _archiver : (_archiver?.default ?? _archiver);
\`\`\`

| Module | Pattern | Reason |
|---|---|---|
| `command-stream` | `const { $ } = _commandStream` | `$` is a named export at top level — no `.default` needed |
| `yargs` | `typeof fn ? fn : fn.default ?? fn` | Callable default export wrapped under `.default` |
| `yargs/helpers` | `x.hideBin ?? x.default.hideBin ?? fallback` | Named export `hideBin` is under `.default` |
| `archiver` | `typeof fn ? fn : fn.default ?? fn` | Callable default export wrapped under `.default` |

## Testing

Verified on Node.js v24.12.0 — `claude-profiles --store global` and `claude-profiles --help` work correctly after the fix.